### PR TITLE
Add ipaddr support

### DIFF
--- a/lib/ipaddr_validator.rb
+++ b/lib/ipaddr_validator.rb
@@ -23,7 +23,12 @@ class IpaddrValidator < ActiveModel::EachValidator
     private
 
     def validate_single_ipaddr(string, options)
-      ip = IPAddr.new(string)
+      ip =
+        if string.is_a?(IPAddr)
+          string
+        else
+           IPAddr.new(string)
+        end
       case
       when options[:ipv4] && ip.ipv4?
         true

--- a/lib/ipaddr_validator.rb
+++ b/lib/ipaddr_validator.rb
@@ -11,8 +11,8 @@ class IpaddrValidator < ActiveModel::EachValidator
         else
           [value]
         end
-      array.all? do |string|
-        validate_single_ipaddr(string, options)
+      array.all? do |value|
+        validate_single_ipaddr(value, options)
       end
     end
 
@@ -22,12 +22,12 @@ class IpaddrValidator < ActiveModel::EachValidator
 
     private
 
-    def validate_single_ipaddr(string, options)
+    def validate_single_ipaddr(value, options)
       ip =
-        if string.is_a?(IPAddr)
-          string
+        if value.is_a?(IPAddr)
+          value
         else
-           IPAddr.new(string)
+           IPAddr.new(value)
         end
       case
       when options[:ipv4] && ip.ipv4?

--- a/spec/ipaddr_validator_spec.rb
+++ b/spec/ipaddr_validator_spec.rb
@@ -38,6 +38,41 @@ shared_examples_for 'invalid array is given', given: :invalid_array do
   end
 end
 
+shared_examples_for 'valid IPv4 IPAddr is given', given: :ipv4_ipaddr do
+  let(:value) do
+    IPAddr.new('192.168.2.0/24')
+  end
+end
+
+shared_examples_for 'valid IPv6 IPAddr is given', given: :ipv6_ipaddr do
+  let(:value) do
+    IPAddr.new('3ffe:505:2::1')
+  end
+end
+
+shared_examples_for 'valid IPv4 array of IPAddrs is given', given: :ipv4_array_ipaddr do
+  let(:value) do
+    [IPAddr.new('192.168.2.0/24'), IPAddr.new('192.168.3.0/24')]
+  end
+end
+
+shared_examples_for 'valid IPv6 array of IPAddrs is given', given: :ipv6_array_ipaddr do
+  let(:value) do
+    [IPAddr.new('3ffe:505:2::1'), IPAddr.new('3ffe:505:2::2')]
+  end
+end
+
+shared_examples_for 'invalid string is given', given: :invalid_ipaddr do
+  let(:value) do
+    nil
+  end
+end
+
+shared_examples_for 'invalid array is given', given: :invalid_array_ipaddr do
+  let(:value) do
+    [nil]
+  end
+end
 # Shared examples for options.
 
 IpaddrValidator.default_options.keys.product([true, false]).each do |option, value|
@@ -138,6 +173,92 @@ describe IpaddrValidator do
       end
 
       context 'when an invalid array is given', given: :invalid_array do
+        context 'and array option is true', array: true do
+          it { should be_falsey }
+        end
+
+        context 'and array option is false', array: false do
+          it { should be_falsey }
+        end
+      end
+    end
+
+    context 'when IPAddrs are given' do
+      context 'when a valid IPv4 IPAddr is given', given: :ipv4_ipaddr do
+        context 'and ipv4 option is true', ipv4: true do
+          context 'and array option is true', array: true do
+            it { should be_falsey }
+          end
+
+          context 'and array option is false', array: false do
+            it { should be_truthy }
+          end
+        end
+
+        context 'and ipv4 option is false', ipv4: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when a valid IPv6 IPAddr is given', given: :ipv6_ipaddr do
+        context 'and ipv6 option is true', ipv6: true do
+          context 'and array option is true', array: true do
+            it { should be_falsey }
+          end
+
+          context 'and array option is false', array: false do
+            it { should be_truthy }
+          end
+        end
+
+        context 'and ipv6 option is false', ipv6: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when a valid IPv4 array of IPAddrs is given', given: :ipv4_array_ipaddr do
+        context 'and ipv4 option is true', ipv4: true do
+          context 'and array option is true', array: true do
+            it { should be_truthy }
+          end
+
+          context 'and array option is false', array: false do
+            it { should be_falsey }
+          end
+        end
+
+        context 'and ipv4 option is false', ipv4: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when a valid IPv6 array of IPAddrs is given', given: :ipv6_array_ipaddr do
+        context 'and ipv6 option is true', ipv6: true do
+          context 'and array option is true', array: true do
+            it { should be_truthy }
+          end
+
+          context 'and array option is false', array: false do
+            it { should be_falsey }
+          end
+        end
+
+        context 'and ipv6 option is false', ipv6: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when an invalid IPAddr is given', given: :invalid_ipaddr do
+        context 'and array option is true', array: true do
+          it { should be_falsey }
+        end
+
+        context 'and array option is false', array: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when an invalid array  of IPAddrs is given', given: :invalid_array_ipaddr do
         context 'and array option is true', array: true do
           it { should be_falsey }
         end

--- a/spec/ipaddr_validator_spec.rb
+++ b/spec/ipaddr_validator_spec.rb
@@ -62,87 +62,89 @@ describe IpaddrValidator do
       described_class.valid?(value, options)
     end
 
-    context 'when a valid IPv4 string is given', given: :ipv4 do
-      context 'and ipv4 option is true', ipv4: true do
+    context 'when strings are given' do
+      context 'when a valid IPv4 string is given', given: :ipv4 do
+        context 'and ipv4 option is true', ipv4: true do
+          context 'and array option is true', array: true do
+            it { should be_falsey }
+          end
+
+          context 'and array option is false', array: false do
+            it { should be_truthy }
+          end
+        end
+
+        context 'and ipv4 option is false', ipv4: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when a valid IPv6 string is given', given: :ipv6 do
+        context 'and ipv6 option is true', ipv6: true do
+          context 'and array option is true', array: true do
+            it { should be_falsey }
+          end
+
+          context 'and array option is false', array: false do
+            it { should be_truthy }
+          end
+        end
+
+        context 'and ipv6 option is false', ipv6: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when a valid IPv4 array is given', given: :ipv4_array do
+        context 'and ipv4 option is true', ipv4: true do
+          context 'and array option is true', array: true do
+            it { should be_truthy }
+          end
+
+          context 'and array option is false', array: false do
+            it { should be_falsey }
+          end
+        end
+
+        context 'and ipv4 option is false', ipv4: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when a valid IPv6 array is given', given: :ipv6_array do
+        context 'and ipv6 option is true', ipv6: true do
+          context 'and array option is true', array: true do
+            it { should be_truthy }
+          end
+
+          context 'and array option is false', array: false do
+            it { should be_falsey }
+          end
+        end
+
+        context 'and ipv6 option is false', ipv6: false do
+          it { should be_falsey }
+        end
+      end
+
+      context 'when an invalid string is given', given: :invalid do
         context 'and array option is true', array: true do
           it { should be_falsey }
         end
 
         context 'and array option is false', array: false do
-          it { should be_truthy }
+          it { should be_falsey }
         end
       end
 
-      context 'and ipv4 option is false', ipv4: false do
-        it { should be_falsey }
-      end
-    end
-
-    context 'when a valid IPv6 string is given', given: :ipv6 do
-      context 'and ipv6 option is true', ipv6: true do
+      context 'when an invalid array is given', given: :invalid_array do
         context 'and array option is true', array: true do
           it { should be_falsey }
         end
 
         context 'and array option is false', array: false do
-          it { should be_truthy }
-        end
-      end
-
-      context 'and ipv6 option is false', ipv6: false do
-        it { should be_falsey }
-      end
-    end
-
-    context 'when a valid IPv4 array is given', given: :ipv4_array do
-      context 'and ipv4 option is true', ipv4: true do
-        context 'and array option is true', array: true do
-          it { should be_truthy }
-        end
-
-        context 'and array option is false', array: false do
           it { should be_falsey }
         end
-      end
-
-      context 'and ipv4 option is false', ipv4: false do
-        it { should be_falsey }
-      end
-    end
-
-    context 'when a valid IPv6 array is given', given: :ipv6_array do
-      context 'and ipv6 option is true', ipv6: true do
-        context 'and array option is true', array: true do
-          it { should be_truthy }
-        end
-
-        context 'and array option is false', array: false do
-          it { should be_falsey }
-        end
-      end
-
-      context 'and ipv6 option is false', ipv6: false do
-        it { should be_falsey }
-      end
-    end
-
-    context 'when an invalid string is given', given: :invalid do
-      context 'and array option is true', array: true do
-        it { should be_falsey }
-      end
-
-      context 'and array option is false', array: false do
-        it { should be_falsey }
-      end
-    end
-
-    context 'when an invalid array is given', given: :invalid_array do
-      context 'and array option is true', array: true do
-        it { should be_falsey }
-      end
-
-      context 'and array option is false', array: false do
-        it { should be_falsey }
       end
     end
   end


### PR DESCRIPTION
We're using [ActiveRecord's support for network address types](http://edgeguides.rubyonrails.org/active_record_postgresql.html#network-address-types) in our app, and I wanted to add validation to a form. I started using this gem, but it expects the ActiveModel attribute to be a string. Since what we have is an `IPAddr` in the attribute, I added support to this gem for it.

The code simply skips the `IPAddr` wrapping if the value is already an IPAddr. I added a bunch of specs for it, mimicking the specs you already have. I do not know about bumping gem versions, of that kind of stuff, though :P

If you need me to change anything, just say so. Thanks for your time! :D
